### PR TITLE
V4.0.4/service update

### DIFF
--- a/.nuget/Codebelt.Bootstrapper.Console/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Bootstrapper.Console/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 4.0.3
+﻿Version 4.0.4
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 4.0.3
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Codebelt.Bootstrapper.Web/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Bootstrapper.Web/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 4.0.3
+﻿Version 4.0.4
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 4.0.3
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Codebelt.Bootstrapper.Worker/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Bootstrapper.Worker/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 4.0.3
+﻿Version 4.0.4
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 4.0.3
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Codebelt.Bootstrapper/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Bootstrapper/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 4.0.3
+﻿Version 4.0.4
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 4.0.3
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 For more details, please refer to `PackageReleaseNotes.txt` on a per assembly basis in the `.nuget` folder.
 
+## [4.0.4] - 2025-08-20
+
+This is a service update that focuses on package dependencies.
+
 ## [4.0.3] - 2025-07-11
 
 This is a service update that focuses on package dependencies.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,27 +3,27 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Codebelt.Extensions.Swashbuckle.AspNetCore" Version="9.0.5" />
-    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="10.0.4" />
-    <PackageVersion Include="Cuemon.Core" Version="9.0.7" />
-    <PackageVersion Include="Cuemon.Extensions.Hosting" Version="9.0.7" />
+    <PackageVersion Include="Codebelt.Extensions.Swashbuckle.AspNetCore" Version="9.0.6" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="10.0.5" />
+    <PackageVersion Include="Cuemon.Core" Version="9.0.8" />
+    <PackageVersion Include="Cuemon.Extensions.Hosting" Version="9.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.18" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.18" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.19" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.19" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -9,7 +9,7 @@
         {
             "name": "Docker-Ubuntu",
             "type": "docker",
-            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.412-9.0.302"
+            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.413-9.0.304"
         }
     ]
 }


### PR DESCRIPTION
This pull request is a service update focused on upgrading package dependencies across the project to ensure compatibility with .NET 9 and .NET 8. All relevant release notes and documentation have been updated to reflect these changes.

Dependency upgrades:

* Updated several package versions in `Directory.Packages.props` for both general and target framework-specific dependencies, including `Codebelt.Extensions.Swashbuckle.AspNetCore`, `Codebelt.Extensions.Xunit.App`, `Cuemon.Core`, `Cuemon.Extensions.Hosting`, `xunit.runner.visualstudio`, and various Microsoft packages for .NET 9 and .NET 8.
* Updated the Docker test environment image in `testenvironments.json` to use newer .NET 8 and .NET 9 patch versions.

Documentation and release notes:

* Added release notes for version 4.0.4 in all `PackageReleaseNotes.txt` files, specifying upgraded dependencies and continued support for .NET 9 and .NET 8. [[1]](diffhunk://#diff-4ad8f29cb6c53083679a36d30f4a4a9f7f67a8a2530efd4621da15e1f775b5f2L1-R7) [[2]](diffhunk://#diff-2cf3d5b1f63550736f63dccdb2448296faf664eca98c3c8068c52f21a5bf7c71L1-R7) [[3]](diffhunk://#diff-fbcd196faa9828a0562b32bbf51122b1c12c76b7558e52f6a13a842674fdc02aL1-R7) [[4]](diffhunk://#diff-00d8d9fd42435c73dd946fbdd0d4fe0d10770b5588d6eb63726c3108770224a8L1-R7)
* Updated `CHANGELOG.md` to document the 4.0.4 service update and its focus on package dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Added 4.0.4 release notes for all Bootstrapper packages with availability for .NET 9 and .NET 8.
  * Updated changelog with 4.0.4 service update entry.
  * Adjusted historical notes: moved dependency-change item from 4.0.3 to 4.0.4; removed two outdated breaking-change entries from 4.0.0 (console).

* Chores
  * Upgraded package dependencies to latest compatible versions across .NET 9 and .NET 8 targets.

* Tests
  * Updated Ubuntu test runner Docker image to newer tag for CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->