### PR TITLE
Add context7.json with URL and public key

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/codebeltnet/bootstrapper",
+  "public_key": "pk_ZYmd0ipMJCtW5NudkKPxA"
+}


### PR DESCRIPTION
This pull request adds a new configuration file, `context7.json`, which contains a URL and a public key for the `bootstrapper` service. This change prepares the project for integration with the external Context7 service.

Configuration update:

* Added `context7.json` file with `url` and `public_key` fields for Context7 bootstrapper integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new configuration settings to support platform operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->